### PR TITLE
Proposal: Auto-sync MII-Packages + Overrides-Konvention

### DIFF
--- a/.github/workflows/sync-mii-packages.yml
+++ b/.github/workflows/sync-mii-packages.yml
@@ -1,0 +1,112 @@
+name: Sync MII Packages
+
+# Tägliches Polling der in repos.yaml gelisteten MII-Repos. Neue Releases
+# werden als .tgz heruntergeladen und als batched PR vorgeschlagen.
+# Kein Auto-Merge — Maintainer reviewen vor dem Mergen, damit broken Upstream-
+# Builds (siehe Mikrobio alpha-2 ohne Snapshots) nicht in den Cache schlüpfen.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # täglich 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Fetch latest releases per repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          changes=0
+          summary=""
+
+          count=$(yq '.repos | length' repos.yaml)
+          for i in $(seq 0 $((count - 1))); do
+            repo=$(yq ".repos[$i].repo" repos.yaml)
+            allow_pre=$(yq ".repos[$i].allow_prerelease // false" repos.yaml)
+            skip=$(yq ".repos[$i].skip // false" repos.yaml)
+
+            if [ "$skip" = "true" ]; then
+              echo "SKIP $repo (skip:true in repos.yaml)"
+              continue
+            fi
+
+            # Latest release oder latest including prerelease
+            if [ "$allow_pre" = "true" ]; then
+              tag=$(gh release list --repo "$repo" --limit 1 --json tagName --jq '.[0].tagName' || echo "")
+            else
+              tag=$(gh release view --repo "$repo" --json tagName --jq '.tagName' 2>/dev/null || echo "")
+            fi
+
+            if [ -z "$tag" ]; then
+              echo "WARN $repo: no release found"
+              continue
+            fi
+
+            asset=$(gh release view "$tag" --repo "$repo" --json assets \
+              --jq ".assets[] | select(.name | endswith(\".tgz\")) | .name" | head -1)
+
+            if [ -z "$asset" ]; then
+              echo "WARN $repo $tag: no .tgz asset"
+              continue
+            fi
+
+            if [ -f "package-tarballs/$asset" ]; then
+              echo "OK   $repo $tag — already cached ($asset)"
+              continue
+            fi
+
+            echo "NEW  $repo $tag → $asset"
+            gh release download "$tag" --repo "$repo" -p "$asset" -D package-tarballs/
+            changes=$((changes + 1))
+            summary="$summary"$'\n'"- \`$repo\` $tag → \`$asset\`"
+          done
+
+          if [ "$changes" -eq 0 ]; then
+            echo "No new packages."
+            echo "HAS_CHANGES=false" >> "$GITHUB_ENV"
+          else
+            {
+              echo "HAS_CHANGES=true"
+              echo "PR_BODY<<EOF_PR"
+              echo "## Auto-Sync Ergebnis"
+              echo ""
+              echo "$changes neue MII-Paket(e) auf Basis von \`repos.yaml\`:"
+              echo "$summary"
+              echo ""
+              echo "Trigger: scheduled run (06:00 UTC)"
+              echo ""
+              echo "**Review-Hinweise:**"
+              echo "- Snapshots prüfen: \`tar -xOzf <pkg> package/StructureDefinition-*.json | jq '.snapshot.element | length'\`"
+              echo "- Bei kaputtem Upstream-Build (z.B. ohne Snapshots): PR schließen, \`repos.yaml\` auf \`skip: true\` setzen, lokal patchen + unter \`overrides/\` einchecken"
+              echo ""
+              echo "cc @ThomasDeBe @julsas"
+              echo "EOF_PR"
+            } >> "$GITHUB_ENV"
+          fi
+
+      - name: Open PR with new tarballs
+        if: env.HAS_CHANGES == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: auto/mii-package-sync
+          title: "Auto: sync MII package releases"
+          body: ${{ env.PR_BODY }}
+          commit-message: "Auto-sync: new MII package releases"
+          labels: auto-sync
+          reviewers: ThomasDeBe,julsas
+          delete-branch: true

--- a/package-tarballs/overrides/README.md
+++ b/package-tarballs/overrides/README.md
@@ -1,0 +1,25 @@
+# Overrides
+
+Tarballs in `package-tarballs/` ohne Unterverzeichnis sind 1:1 die offiziellen Upstream-Builds.
+
+Tarballs hier in `overrides/` sind **lokal modifizierte Varianten**, weil der Upstream-Build kaputt oder unvollständig ist und Downstream-Konsumenten den nicht direkt nutzen können. Beispiele:
+
+| Datei | Grund | Resolution-Trigger |
+|---|---|---|
+| `*-snapshots.tgz` | Upstream-Tarball wurde ohne Snapshots publiziert (Bake-Step fehlte). Lokal mit `fhir bake` regeneriert. | Sobald der Modul-Pflegende einen neuen Tarball mit Snapshots publiziert. |
+
+## Convention
+
+- Dateiname trägt einen **Suffix** der die Modifikation beschreibt: `-snapshots`, `-patched`, etc. Die `version` im `package.json` innerhalb des Tarballs bleibt **unverändert** — Firely Terminal löst die Version aus dem Verzeichnisnamen `<name>#<version>` (siehe Workflow `Build FHIR Cache from .tgz Packages`, der den Suffix beim Cache-Layout abschneidet).
+- Pro Override ein Eintrag in der Tabelle oben mit dem Resolution-Trigger.
+
+## Lifecycle
+
+1. Override wird hinzugefügt, wenn ein Upstream-Build broken ist und Downstream blockiert
+2. Issue im Upstream-Repo eröffnen (Link in der Tabelle oben dokumentieren, sobald vorhanden)
+3. Sobald Upstream gefixt: Override entfernen, offiziellen Tarball via Auto-Sync ziehen lassen
+4. Auto-Sync respektiert Overrides nicht — der `skip: true` Flag in `repos.yaml` verhindert, dass die kaputte Version den Override überschreibt
+
+## Aktuelle Overrides
+
+(Keine — Stand: Initial-Setup. Mikrobio `2027.0.0-alpha.2-snapshots.tgz` liegt aktuell im Hauptverzeichnis und wird beim nächsten Override-Setup-PR umgezogen.)

--- a/repos.yaml
+++ b/repos.yaml
@@ -38,3 +38,4 @@ repos:
   # ===== Cross-Module =====
   - repo: medizininformatik-initiative/kerndatensatz-meta
   - repo: medizininformatik-initiative/kerndatensatz-complete
+  - repo: medizininformatik-initiative/kds-fdpg-layer            # FDPG Overlay-Layer (eigenes Release-tgz)

--- a/repos.yaml
+++ b/repos.yaml
@@ -1,0 +1,40 @@
+# Tracked upstream repositories for auto-sync of FHIR package tarballs.
+#
+# Der Workflow .github/workflows/sync-mii-packages.yml liest diese Datei einmal
+# pro Lauf, holt den jeweils letzten Release (oder pre-release wenn
+# allow_prerelease: true), lädt den .tgz-Asset, und stellt einen batched PR
+# zum Review.
+#
+# Felder:
+#   repo               GitHub owner/name (required)
+#   allow_prerelease   true → auch alpha/beta/rc Releases ziehen. Default false.
+#                      Module, deren "aktiver" Release aktuell ein Prerelease ist
+#                      (consent, mikrobiologie), setzen das explizit.
+#   skip               true → temporär deaktivieren (z.B. weil upstream broken
+#                      und unter overrides/ lokal gepatcht)
+
+repos:
+  # ===== KDS Module =====
+  - repo: medizininformatik-initiative/kerndatensatz-basis
+  - repo: medizininformatik-initiative/kerndatensatzmodul-labor
+  - repo: medizininformatik-initiative/kerndatensatzmodul-medikation
+  - repo: medizininformatik-initiative/kerndatensatzmodul-biobank
+  - repo: medizininformatik-initiative/kerndatensatzmodul-studie
+  - repo: medizininformatik-initiative/kerndatensatzmodul-GenetischeTests   # publiziert als kerndatensatz.molgen — TODO verify
+  - repo: medizininformatik-initiative/kerndatensatzmodul-PathologieBefund
+  - repo: medizininformatik-initiative/kerndatensatzmodul-intensivmedizin
+  - repo: medizininformatik-initiative/kerndatensatz-bildgebung
+  - repo: medizininformatik-initiative/kerndatensatzmodul-seltene-erkrankungen
+  - repo: medizininformatik-initiative/kerndatensatzmodul-onkologie
+  - repo: medizininformatik-initiative/kerndatensatz-dokument
+  - repo: medizininformatik-initiative/kerndatensatzmodul-molekulares-tumorboard
+  - repo: medizininformatik-initiative/kerndatensatzmodul-proms
+  - repo: medizininformatik-initiative/kerndatensatzmodul-consent
+    allow_prerelease: true
+  - repo: medizininformatik-initiative/kerndatensatzmodul-mikrobiologie
+    allow_prerelease: true
+    skip: true   # bis alpha-3 mit Snapshots upstream da ist
+
+  # ===== Cross-Module =====
+  - repo: medizininformatik-initiative/kerndatensatz-meta
+  - repo: medizininformatik-initiative/kerndatensatz-complete

--- a/repos.yaml
+++ b/repos.yaml
@@ -20,7 +20,7 @@ repos:
   - repo: medizininformatik-initiative/kerndatensatzmodul-medikation
   - repo: medizininformatik-initiative/kerndatensatzmodul-biobank
   - repo: medizininformatik-initiative/kerndatensatzmodul-studie
-  - repo: medizininformatik-initiative/kerndatensatzmodul-GenetischeTests   # publiziert als kerndatensatz.molgen — TODO verify
+  - repo: medizininformatik-initiative/kerndatensatzmodul-GenetischeTests   # publiziert als de.medizininformatikinitiative.kerndatensatz.molgen
   - repo: medizininformatik-initiative/kerndatensatzmodul-PathologieBefund
   - repo: medizininformatik-initiative/kerndatensatzmodul-intensivmedizin
   - repo: medizininformatik-initiative/kerndatensatz-bildgebung


### PR DESCRIPTION
## Zusammenfassung

Vorschlag für **automatisches Tracking neuer Releases** aus den MII-Modul-Repos, plus eine **explizite Konvention für Override-Tarballs** (z.B. lokal nachgenerierte Snapshots).

Hintergrund: Beim Build von `kds-fdpg-layer v2026.1.0` ist aufgefallen, dass der Store ~6 Wochen hinter den aktuellen Modul-Versionen lag und mehrere Pakete (mikrobiologie alpha-2, consent rc-2, pros 2026.3.0, complete 2026.1.0) komplett fehlten. Manuell nachpflegen funktioniert, aber das verschlechtert sich, je mehr Module Releases ziehen.

## Drei Bausteine

### 1. `repos.yaml` — getrackte Upstream-Repos

18 MII-Repos in einer YAML-Whitelist. Pro Repo zwei optionale Flags:

- `allow_prerelease: true` für Module, die aktuell auf RC/Alpha-Track sind (z.B. `consent`, `mikrobiologie`)
- `skip: true` für temporäres Deaktivieren, wenn Upstream broken ist (z.B. `mikrobiologie` aktuell, bis alpha-3 mit Snapshots upstream ist)

Hinzufügen eines neuen Repos = ein Eintrag in der Liste.

### 2. `.github/workflows/sync-mii-packages.yml` — scheduled Action

- Daily 06:00 UTC
- Pro Repo: latest Release ermitteln, .tgz-Asset prüfen, runterladen wenn noch nicht im Store
- Batched PR mit allen neuen Tarballs, gepingt `@ThomasDeBe` + `@julsas` als Reviewer
- **Kein Auto-Merge** — Maintainer reviewen, weil Upstream auch broken sein kann (siehe Mikrobio alpha-2 ohne Snapshots)

### 3. `package-tarballs/overrides/` + README

Explizite Konvention für Tarballs, die NICHT 1:1 vom Upstream-Release stammen, sondern lokal modifiziert wurden (typisch: nachgebakede Snapshots). Lifecycle und Filename-Convention dokumentiert.

## Diskussionspunkte

- **Reviewer-Liste**: aktuell `@ThomasDeBe` + `@julsas`. Wer sollte sonst noch eingebunden sein?
- **Cron-Frequenz**: täglich vs. wöchentlich — Volumen ist gering, daily sollte tragbar sein
- **Repo-Liste vollständig?** `kerndatensatzmodul-GenetischeTests` ist mit TODO markiert (= molgen?). Sind weitere relevante Repos in der MII-Org, die wir tracken sollten?
- **Maintainer-Berechtigung**: braucht der Workflow zusätzliche Permissions/Secrets? Aktuell nur `GITHUB_TOKEN` mit contents:write + pull-requests:write.

## Test plan

- [ ] Workflow `workflow_dispatch` triggern (manuell), Output-PR prüfen
- [ ] Mit `skip: true` für ein Repo verifizieren, dass es ausgelassen wird
- [ ] PR-Schließen + `skip: true` für ein anderes Modul setzen — bestätigen, dass danach kein PR mehr für dieses Modul kommt
- [ ] Mit allow_prerelease=true verifizieren, dass alpha/RC gezogen wird

Als **Draft** geöffnet zur Diskussion. Implementation kann nach Konsens noch angepasst werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)